### PR TITLE
feat (FEC-73) Use same language dropdown for signup and signin

### DIFF
--- a/src/pages/signIn/index.jsx
+++ b/src/pages/signIn/index.jsx
@@ -53,19 +53,12 @@ const SignIn = () => {
                 <span className="font-bold text-3xl lg:text-5xl ml-1">Up</span>
               </Link>
               </div>
-              <div className="relative">
-                <label className="block mt-4">
-                  <img
-                    className="flag-image absolute top-[26px] left-[8px]"
-                    src={nigeriaFlag}
-                    alt=" "
-                  />
-                  <select className="language-select font-bold text-black text-center rounded-2xl mt-1 block w-[140px] px-6 py-2 bg-blue-100">
-                    <option className="bg-blue-200">English</option>
-                    <option className="bg-blue-200">French</option>
-                    <option className="bg-blue-200">German</option>
-                  </select>
-                </label>
+              <div className='px-1 rounded-[20px] w-29 tablet:w-35 tablet:h-10 h-[34px]  bg-blue-100 flex justify-around items-center'>
+                <img className='w-5' src={nigeriaFlag} alt="nigerian flag" />
+                <select className='language-select bg-blue-100 w-full font-semibold focus:outline-none text-xs tablet:text-sm' name="language" id="language">
+                  <option value="uk">English (UK)</option>
+                  <option value="us">English (US)</option>
+                </select>
               </div>
             </div>
             <div className="px-2 lg:px-14 mt-10 lg:mt-14">

--- a/src/pages/signUp/index.jsx
+++ b/src/pages/signUp/index.jsx
@@ -82,14 +82,12 @@ const SignUp = () => {
       <div className=' w-full h-full bg-white tablet:w-6/12 tablet:p-3.5 mx-auto '>
         <header className=' w-full flex justify-between items-center px-4 pt-4 mt-3.5 tablet:mt-0'>
         <Link to='/'><img className='w-32 tablet:w-48' src={catchup} alt="logo of app" /></Link>
-          <div className='px-1 rounded-[20px] w-29 tablet:w-32 tablet:h-10 h-[34px]  bg-blue-100 flex justify-around items-center'>
+          <div className='px-1 rounded-[20px] w-29 tablet:w-35 tablet:h-10 h-[34px]  bg-blue-100 flex justify-around items-center'>
             <img className='w-5' src={nigeria} alt="nigerian flag" />
-            <select className='bg-blue-100 w-full font-semibold focus:outline-none text-xs tablet:text-sm' name="language" id="language">
+            <select className='language-select bg-blue-100 w-full font-semibold focus:outline-none text-xs tablet:text-sm' name="language" id="language">
               <option value="uk">English (UK)</option>
               <option value="us">English (US)</option>
             </select>
-
-
           </div>
         </header>
         <div className='mt-10 tablet:mt-14 px-4 w-full max-w-md mx-auto'>


### PR DESCRIPTION
In this PR, I adjusted the content of the language dropdown to be same on mobile and desktop view

Before 👇🏽 
![image](https://user-images.githubusercontent.com/63473584/204545353-a82d524a-be51-4bcc-8792-50786eb0b318.png)
![image](https://user-images.githubusercontent.com/63473584/204545606-ed4188e2-3ac9-4853-af5a-4e741dca6996.png)

Now 👇🏽 

![image](https://user-images.githubusercontent.com/63473584/204545770-f31cc3b3-a825-4fc4-8939-b37eb3b48d3b.png)
![image](https://user-images.githubusercontent.com/63473584/204545960-7c35131a-f540-4702-8d5e-0dd8928c2b8c.png)
